### PR TITLE
dact show selected language

### DIFF
--- a/templates/locales-banner.njk
+++ b/templates/locales-banner.njk
@@ -14,11 +14,15 @@ It receives:
             <ul class="govuk-language-select__list">
             {% if languageEnabled %}
                {% for l in languages %}
-                <li class="govuk-language-select__list-item">
-                    <a href="{{lang2url.addLangToUrl(currentUrl, l.IsoCode, true)}}" lang={{l.IsoCode}} rel="alternate" class="govuk-link" >
-                        <span>{{l.Name}}</span>
-                    </a>
-                </li>
+                 <li class="govuk-language-select__list-item">
+                 {% if lang == l.IsoCode %}
+                   <span class="govuk-body-s govuk-!-margin-2">{{l.Name}}</span>
+                 {% else %}
+                   <a href="{{lang2url.addLangToUrl(currentUrl, l.IsoCode, true)}}" lang={{l.IsoCode}} rel="alternate" class="govuk-link govuk-!-margin-2" >
+                      <span>{{l.Name}}</span>
+                   </a>
+                 {% endif %}
+                 </li>
                {% endfor %}
             {% endif %}
             </ul>

--- a/templates/locales-banner.njk
+++ b/templates/locales-banner.njk
@@ -15,7 +15,7 @@ It receives:
             {% if languageEnabled %}
                {% for l in languages %}
                  <li class="govuk-language-select__list-item">
-                 {% if lang == l.IsoCode %}
+                 {% if lang and lang == l.IsoCode %}
                    <span class="govuk-body-s govuk-!-margin-2">{{l.Name}}</span>
                  {% else %}
                    <a href="{{lang2url.addLangToUrl(currentUrl, l.IsoCode, true)}}" lang={{l.IsoCode}} rel="alternate" class="govuk-link govuk-!-margin-2" >


### PR DESCRIPTION
Suggested improvement to the language banner to show the current language without a link underline / non selectable. Also adds a bit more spacing. Only tested a local copy of this change. Page showing both current and changed banner:

![Screenshot 2024-03-27 at 13 33 29](https://github.com/companieshouse/ch-node-utils/assets/117173564/91d98cb7-c44d-4de6-b87b-8792552a91c2)

With this change both currentUrl must lang should be passed in to the nunjucks/HTML template on each page that includes the banner.