### PR TITLE
handle req.body being null

### DIFF
--- a/src/middleware/manageLocales.middleware.ts
+++ b/src/middleware/manageLocales.middleware.ts
@@ -9,10 +9,11 @@ export function LocalesMiddleware (): RequestHandler {
     return (req: Request, res: Response, next: NextFunction) => {
 
         log("---------- LocalesMiddleware ------------")
-        let lang: string | undefined = (<string>req.query[QUERY_PAR_LANG] ||
-            req.body.lang ||
-            req.session?.getExtraData<string>(QUERY_PAR_LANG))
-        log(`LocalesMiddleware ....(init with received values: lang=${lang}) - body:${req.body.lang})`)
+        let lang: string | undefined =
+            (<string>req.query[QUERY_PAR_LANG]) ||
+            req.body?.lang ||
+            req.session?.getExtraData<string>(QUERY_PAR_LANG);
+            log(`LocalesMiddleware ....(init with received values: lang=${lang}) - body:${req.body?.lang ?? 'N/A'})`)
         if (lang === undefined || !LanguageNames.isSupportedLocale(LocalesService.getInstance().localesFolder, lang)) {
             lang = "en"
         }


### PR DESCRIPTION
**Fix**:

Unlike the [null test in the session](https://github.com/companieshouse/ch-node-utils/commit/a96d0eb8d1f351a26e6df075c06e0a7b45c9e0d4#diff-7f1c30e5221df1dd8db430c061b601a5d3e5e66dd38b890e590419656e1969b0R12), the one on the `req.body` was missed when it was introduced
