### PR TITLE
Add optional CSP nonce to script tag

### DIFF
--- a/templates/locales-banner.njk
+++ b/templates/locales-banner.njk
@@ -35,7 +35,7 @@ It receives:
     </div>
 </div>
 
-<script>
+<script {% if cspNonce %} nonce={{ cspNonce | dump | safe }} {% endif %}>
   document.addEventListener('DOMContentLoaded', function() {
     const languageLinks = document.querySelectorAll('.language-link');
 


### PR DESCRIPTION
Add an optional csp nonce attribute  in the script tag in the locales-banner to prevent csp errors