### PR TITLE
Adding page language to links in predefined nav bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The macro requires the following parameters:
 - `displayAuthorisedAgent`: A flag for displaying the "Authorised agent" menu item. If the logged user has ACSP membership, this flag should be set to `'yes'`. If your service uses i18 middleware provided in the `@companieshouse/ch-node-utils` package, then this flag will be set to the correct value automatically. If not, you can use `isAuthorisedAgent` function from `./utils/sessionUtils`.
 - `displayYourCompanies`: A flag for displaying the "Your companies" menu item. It should be set to `'yes` if this menu iten needs to be displayed.
 - `displayUserManagementAdmin`: A flag for displaying the "User management admin" menu item. It should be set to `'yes` if this menu iten needs to be displayed.
+- `pageLanguage`: The language code for the page. (e.g. `'en'` or `'cy'`). This allows the language to be kept after navigating to the new service.
 
 #### Localization
 

--- a/templates/navbar.njk
+++ b/templates/navbar.njk
@@ -62,16 +62,17 @@ It receives:
 - displayAuthorisedAgent: a flag indicating whether to display the 'Authorised agent' menu item
 - displayYourCompanies: a flag indicating whether to display the 'Your companies' menu item
 - displayUserManagementAdmin: a flag indicating whether to display the 'User management admin' menu item
+- pageLanguage: the language code for the page (e.g. 'en', 'cy')
 #}
-{% macro addPredefinedNavbar(userDisplayText, chsMonitorGuiUrl, lang, displayAuthorisedAgent, displayYourCompanies, displayUserManagementAdmin) %}
+{% macro addPredefinedNavbar(userDisplayText, chsMonitorGuiUrl, lang, displayAuthorisedAgent, displayYourCompanies, displayUserManagementAdmin, pageLanguage) %}
     {% set menuItems = [
-        { id: "user-management-admin", href: "/identity-verification", displayText: lang.userManagementAdmin or "User management admin" } if displayUserManagementAdmin === "yes",
-        { id: "authorised-agent", href: "/authorised-agent", displayText: lang.authorisedAgent or "Authorised agent" } if displayAuthorisedAgent === "yes",
-        { id: "your-companies", href: "/your-companies", displayText: lang.yourCompanies or "Your companies" } if displayYourCompanies === "yes",
-        { id: "your-filings", href: "/user/transactions", displayText: lang.yourFilings or "Your filings" },
+        { id: "user-management-admin", href: "/identity-verification?lang=" + pageLanguage, displayText: lang.userManagementAdmin or "User management admin" } if displayUserManagementAdmin === "yes",
+        { id: "authorised-agent", href: "/authorised-agent?lang=" + pageLanguage, displayText: lang.authorisedAgent or "Authorised agent" } if displayAuthorisedAgent === "yes",
+        { id: "your-companies", href: "/your-companies?lang=" + pageLanguage, displayText: lang.yourCompanies or "Your companies" } if displayYourCompanies === "yes",
+        { id: "your-filings", href: "/user/transactions?lang=" + pageLanguage, displayText: lang.yourFilings or "Your filings" },
         { id: "companies-you-follow", href: chsMonitorGuiUrl, displayText: lang.companiesYouFollow or "Companies you follow" },
-        { id: "basket", href: "/basket", displayText: lang.basket or "Basket" },
-        { id: "your-details", href: "/user/account", displayText: lang.manageAccount or "Manage account" },
+        { id: "basket", href: "/basket?lang=" + pageLanguage, displayText: lang.basket or "Basket" },
+        { id: "your-details", href: "/user/account?lang=" + pageLanguage, displayText: lang.manageAccount or "Manage account" },
         { id: "user-signout", href: "/signout", displayText: lang.signOut or "Sign out" }
     ] | reject("falsy") %}
 

--- a/templates/navbar.njk
+++ b/templates/navbar.njk
@@ -64,7 +64,7 @@ It receives:
 - displayUserManagementAdmin: a flag indicating whether to display the 'User management admin' menu item
 - pageLanguage: the language code for the page (e.g. 'en', 'cy')
 #}
-{% macro addPredefinedNavbar(userDisplayText, chsMonitorGuiUrl, lang, displayAuthorisedAgent, displayYourCompanies, displayUserManagementAdmin, pageLanguage) %}
+{% macro addPredefinedNavbar(userDisplayText, chsMonitorGuiUrl, lang, displayAuthorisedAgent, displayYourCompanies, displayUserManagementAdmin, pageLanguage="en") %}
     {% set menuItems = [
         { id: "user-management-admin", href: "/identity-verification?lang=" + pageLanguage, displayText: lang.userManagementAdmin or "User management admin" } if displayUserManagementAdmin === "yes",
         { id: "authorised-agent", href: "/authorised-agent?lang=" + pageLanguage, displayText: lang.authorisedAgent or "Authorised agent" } if displayAuthorisedAgent === "yes",


### PR DESCRIPTION
Ticket [IDVA5-2060](https://companieshouse.atlassian.net/browse/IDVA5-2060)

Adding page language to links in predefined nav bar to keep the current language when the user navigates to that link

Added the new parameter to the readme

[IDVA5-2060]: https://companieshouse.atlassian.net/browse/IDVA5-2060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ