### PR TITLE
Removing spaces from the equals in the nav bar

### DIFF
--- a/templates/navbar.njk
+++ b/templates/navbar.njk
@@ -66,7 +66,7 @@ It receives:
 - pageLanguage: the language code for the page (e.g. 'en', 'cy')
 - accountUrl: base URL to account service - ACCOUNT_URL
 #}
-{% macro addPredefinedNavbar(userDisplayText, chsMonitorGuiUrl, lang, displayAuthorisedAgent, displayYourCompanies, displayUserManagementAdmin, pageLanguage = "en", accountUrl) %}
+{% macro addPredefinedNavbar(userDisplayText, chsMonitorGuiUrl, lang, displayAuthorisedAgent, displayYourCompanies, displayUserManagementAdmin, pageLanguage="en", accountUrl) %}
     {% set menuItems = [
         { id: "user-management-admin", href: "/identity-verification?lang=" + pageLanguage, displayText: lang.userManagementAdmin or "User management admin" } if displayUserManagementAdmin === "yes",
         { id: "authorised-agent", href: "/authorised-agent?lang=" + pageLanguage, displayText: lang.authorisedAgent or "Authorised agent" } if displayAuthorisedAgent === "yes",


### PR DESCRIPTION
Removing spaces from the equals in the nav bar as this was causing the language to not change when a new value was passed in