### PR TITLE
Add Matomo support to navbar <a> tags

### DIFF
--- a/templates/navbar.njk
+++ b/templates/navbar.njk
@@ -46,7 +46,7 @@ It receives:
                 </li>
                 {% for item in menuItems %}
                     <li>
-                        <a class="govuk-link" id="{{ item.id }}" href="{{ item.href }}">{{ item.displayText }}</a>
+                        <a class="govuk-link" id="{{ item.id }}" data-event-id="{{ item.id }}-nav-link" href="{{ item.href }}">{{ item.displayText }}</a>
                     </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
Relates to ticket: https://companieshouse.atlassian.net/browse/IDVA3-2613

Adds a `data-event-id` attribute to the `<a>` tags in the `addNavbar` macro based on the entry's existing `id`. This won't do anything for services that don't explicitly enable Matomo tracking, but for those that do it's a requirement.

Below is a screenshot showing the sign out event being picked up in Matomo.
<img width="402" alt="image" src="https://github.com/user-attachments/assets/5b694dc3-0235-4257-960b-d307b0015755" />
