### PR TITLE
Replace setExtraData and getExtraData with setLanguage and getLanguage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/node-session-handler": "^5.1.4",
+        "@companieshouse/node-session-handler": "^5.2.4",
         "eslint": "^9.14.0",
         "express": "^4.18.3",
         "i18next": "^23.10.1",
@@ -568,9 +568,9 @@
       }
     },
     "node_modules/@companieshouse/node-session-handler": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.2.2.tgz",
-      "integrity": "sha512-chSMyTGoQxo27Lvzc+SMGQuYo2ObnFYAIZ58CERfkBaBeELtV1MWFH9WXl7+XLWpszgD182lOKEFfY/TRUqpHQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.2.4.tgz",
+      "integrity": "sha512-QVm6r9rla/5F10Yk94XoAL7BZnRaGpRJSEfWaRwG6vturONBMF0BpkfGWQQr4i+XEccqqULnp1bB/YDTqFzMdQ==",
       "license": "MIT",
       "dependencies": {
         "@companieshouse/structured-logging-node": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@companieshouse/node-session-handler": "^5.1.4",
+    "@companieshouse/node-session-handler": "^5.2.4",
     "eslint": "^9.14.0",
     "express": "^4.18.3",
     "i18next": "^23.10.1",

--- a/src/middleware/manageLocales.middleware.ts
+++ b/src/middleware/manageLocales.middleware.ts
@@ -12,14 +12,14 @@ export function LocalesMiddleware (): RequestHandler {
         let lang: string | undefined =
             (<string>req.query[QUERY_PAR_LANG]) ||
             req.body?.lang ||
-            req.session?.getExtraData<string>(QUERY_PAR_LANG);
+            req.session?.getLanguage();
             log(`LocalesMiddleware ....(init with received values: lang=${lang}) - body:${req.body?.lang ?? 'N/A'})`)
         if (lang === undefined || !LanguageNames.isSupportedLocale(LocalesService.getInstance().localesFolder, lang)) {
             lang = "en"
         }
         log(`LocalesMiddleware ....(setting lang=${lang})`)
         if (req.session) {
-            req.session.setExtraData(QUERY_PAR_LANG, lang) // when there is a session store it there
+            req.session.setLanguage(lang) // when there is a session store it there
         }
         req.lang = lang // store it also as metadata in the request
 


### PR DESCRIPTION
This PR replaces the `setExtraData` and `getExtraData` methods with `setLanguage` and `getLanguage`
Related to JIRA: [2510](https://companieshouse.atlassian.net/jira/software/c/projects/SIV/boards/451?selectedIssue=IDVA6-2510)