### PR TITLE
Add manifest.json to Page Template

### DIFF
--- a/templates/layouts/template.njk
+++ b/templates/layouts/template.njk
@@ -6,6 +6,11 @@
   {% set _cdnImageRootPath = _cdnImageRootPath + "/rebrand" %}
 {% endif %}
 
+{% set _cdnManifestRootPath = cdnHost + "/static/govuk-frontend/v" + govukFrontendVersion %}
+{% if govukRebrand %}
+  {% set _cdnManifestRootPath = _cdnManifestRootPath + "/rebrand" %}
+{% endif %}
+
 {# GOV.UK Frontend Page Template option for Open Graph https://design-system.service.gov.uk/styles/page-template/#options #}
 {% set opengraphImageUrl = _cdnImageRootPath + "/govuk-opengraph-image.png" %}
 
@@ -15,6 +20,7 @@
   <link rel="icon" sizes="any" href="{{ _cdnImageRootPath }}/favicon.svg" type="image/svg+xml">
   <link rel="mask-icon" href="{{ _cdnImageRootPath }}/govuk-icon-mask.svg" color="{{ themeColor }}">
   <link rel="apple-touch-icon" href="{{ _cdnImageRootPath }}/govuk-icon-180.png">
+  <link rel="manifest" href="{{ _cdnManifestRootPath }}/manifest.json">
 {% endblock %}
 
 {% block head %}

--- a/test/templates/layouts/template.test.ts
+++ b/test/templates/layouts/template.test.ts
@@ -113,6 +113,16 @@ describe("companies house top level template", () => {
             );
         });
 
+        it("links to CDN manifest.json", () => {
+            renderTemplate(govukFrontendVersion);
+            const manifest = document.head.querySelector(
+                `link[rel="manifest"]`
+            );
+            expect(manifest?.getAttribute("href")).toBe(
+                `https://example.cloudfront.net/static/govuk-frontend/v${govukFrontendVersion}/manifest.json`
+            );
+        });
+
         describe("supports govukRebrand mode", () => {
             it("links to CDN icons", () => {
                 renderTemplate(govukFrontendVersion, {
@@ -145,7 +155,19 @@ describe("companies house top level template", () => {
                 expect(appleTouchIcon?.getAttribute("href")).toBe(
                     `https://example.cloudfront.net/images/govuk-frontend/v${govukFrontendVersion}/rebrand/govuk-icon-180.png`
                 );
-            })
+            });
+
+            it("links to rebrand CDN manifest.json", () => {
+                renderTemplate(govukFrontendVersion, {
+                    govukRebrand: true
+                });
+                const manifest = document.head.querySelector(
+                    `link[rel="manifest"]`
+                );
+                expect(manifest?.getAttribute("href")).toBe(
+                    `https://example.cloudfront.net/static/govuk-frontend/v${govukFrontendVersion}/rebrand/manifest.json`
+                );
+            });
         })
     });
     describe("GOV.UK Frontend version 5.10.2", () => {


### PR DESCRIPTION
Allows the Page Template to reference the manifest.json which in turn references mobile icons.