### PR TITLE
Fix peer dependency notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "govuk-frontend": "^4.10.0, ^5.10.0"
+    "govuk-frontend": "^4.10.0 || ^5.10.0"
   },
   "bugs": {
     "url": "https://github.com/companieshouse/ch-node-utils/issues"


### PR DESCRIPTION
Currently only version 5.x is picked up by changing to double pipe 4.x should too.