### PR TITLE
Add support for nonce for inline scripts

### DIFF
--- a/docs/page-template.md
+++ b/docs/page-template.md
@@ -95,6 +95,7 @@ njk.addGlobal("govukRebrand", true);
 | cdnHost | Variable | root domain for the [CDN host](https://github.com/companieshouse/cdn.ch.gov.uk) |
 | govukFrontendVersion | Variable | version of GOV.UK Frontend to use, recommend to set this with the [`getGOVUKFrontendVersion` helper](#getGOVUKFrontendVersion) |
 | govukRebrand | Variable | Enables the new GOV.UK Rebranding, this variable is from the [GOV.UK Frontend Page Template](https://design-system.service.gov.uk/styles/page-template/#options) |
+| nonce | Variable | Allows setting a [`nonce` value for use with a Content Security Policy (CSP)](https://content-security-policy.com/examples/allow-inline-script/) |
 
 ## Setting blocks
 

--- a/templates/layouts/template.njk
+++ b/templates/layouts/template.njk
@@ -31,12 +31,12 @@
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
   {# Starting in GOV.UK Frontend version 5, JavaScript is only loaded in modern browsers using ES6 Module imports. #}
   {% if govukFrontendVersion | first >= "5"  %}
-    <script type="module">
+    <script type="module"{% if nonce %} nonce="{{ nonce }}"{% endif %}>
       import { initAll } from '{{ cdnHost }}/javascripts/govuk-frontend/v{{ govukFrontendVersion }}/govuk-frontend-{{ govukFrontendVersion }}.min.js'
       initAll()
     </script>
   {% else %}
     <script src="{{ cdnHost }}/javascripts/govuk-frontend/v{{ govukFrontendVersion }}/govuk-frontend-{{ govukFrontendVersion }}.min.js"></script>
-    <script>window.GOVUKFrontend.initAll()</script>
+    <script{% if nonce %} nonce="{{ nonce }}"{% endif %}>window.GOVUKFrontend.initAll()</script>
   {% endif %}
 {% endblock %}

--- a/test/templates/layouts/template.test.ts
+++ b/test/templates/layouts/template.test.ts
@@ -123,6 +123,16 @@ describe("companies house top level template", () => {
             );
         });
 
+        it("supports adding nonce values to inline scripts", () => {
+            // Example nonce from: https://content-security-policy.com/examples/allow-inline-script/
+            renderTemplate(govukFrontendVersion, {
+                nonce: "rAnd0m"
+            });
+             const endScript = document.body.lastElementChild;
+            expect(endScript?.tagName).toBe("SCRIPT");
+            expect(endScript?.innerHTML).not.toBe("");
+            expect(endScript?.getAttribute("nonce")).toBe("rAnd0m");
+        });
         describe("supports govukRebrand mode", () => {
             it("links to CDN icons", () => {
                 renderTemplate(govukFrontendVersion, {


### PR DESCRIPTION
If an application is using a Content Security Policy (CSP) then inline scripts will fail the policy and cause the JavaScript not to run.

To avoid this we can use a hash of the inline script, but since the inline script will change depending on the CDN Host and what version of GOV.UK Frontend is being used a nonce attribute can be used instead.

See https://content-security-policy.com/examples/allow-inline-script/ for more info.