### PR TITLE
Implement Matomo CORS error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The navbar uses translations from `@companieshouse/ch-node-utils` (this) package
 
 The navbar also requires the use of styles provided in the [ch.gov.uk.css](https://github.com/companieshouse/cdn.ch.gov.uk/blob/master/app/assets/stylesheets/ch.gov.uk.css) stylesheet (you can either add the provided link to the head section or include specific styles in your own stylesheet)
 
-`<link href="{{ cdnHost }}/stylesheets/ch.gov.uk.css" rel="stylesheet"/>`
+`<link href="{{ cdnHost }}/stylesheets/ch.gov.uk.css" rel="stylesheet" crossorigin="anonymous"/>`
 
 It also requires the [navbar.js](https://github.com/companieshouse/cdn.ch.gov.uk/blob/master/app/assets/javascripts/lib/navbar.js) script to be added to the footer to make the navbar work in mobile mode (make sure it's the latest version).
 

--- a/docs/page-template.md
+++ b/docs/page-template.md
@@ -108,7 +108,7 @@ If you want to extend the `head`, `headIcons` or `bodyEnd` blocks you must call 
 ```handlebars
 {% block head %}
    {{ super() }}
-   <link rel="stylesheets" href="https://example.cloudfront.net/stylesheets/application.css">
+   <link rel="stylesheets" href="https://example.cloudfront.net/stylesheets/application.css" crossorigin="anonymous">
 {% endblock %}
 ```
 ## Helpers

--- a/templates/layouts/template.njk
+++ b/templates/layouts/template.njk
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ cdnHost }}/stylesheets/govuk-frontend/v{{ govukFrontendVersion }}/govuk-frontend-{{ govukFrontendVersion }}.min.css">
+  <link rel="stylesheet" href="{{ cdnHost }}/stylesheets/govuk-frontend/v{{ govukFrontendVersion }}/govuk-frontend-{{ govukFrontendVersion }}.min.css" crossorigin="anonymous">
 {% endblock %}
 
 {% block bodyEnd %}

--- a/templates/navbar.njk
+++ b/templates/navbar.njk
@@ -9,7 +9,7 @@ It also requires the use of styles provided in the following stylesheet
 (you can either add the provided link to the head section or include specific
 styles in your own stylesheet)
 
-    <link href="{{ cdnHost }}/stylesheets/ch.gov.uk.css" rel="stylesheet"/>
+    <link href="{{ cdnHost }}/stylesheets/ch.gov.uk.css" rel="stylesheet" crossorigin="anonymous"/>
 
 It also requires the following script to be added to the footer
 


### PR DESCRIPTION
Part of: https://github.com/companieshouse/psc-verification-web/pull/368

Adds the `crossorigin="anonymous"` attribute to stylesheet links to prevent a web console error when Matomo is accessing CSS files for heatmaps & session recording.

<img width="3790" height="810" alt="image" src="https://github.com/user-attachments/assets/c8be6de2-17e6-4449-bf48-f9e25253dbbd" />

See commit message for further details.